### PR TITLE
Add step to installation & remove 2 critical vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ It is no longer possible to publish packages to the atom package registry. Inste
 1. Make sure that `apm` (atom package manager) is installed. On linux and windows, it should be automatically installed with atom. On OSX, go to the 'Atom' menu, and click 'Install Shell Commands'. 
 2. Download this repository `git clone https://github.com/hydra-synth/atom-hydra.git`
 3. Enter the atom directory `cd atom-hydra`
-4. Load this package `apm link .`
-5. Restart atom 
+4. Install the dependencies  `npm install`
+5. Load this package `apm link .`
+6. Restart atom 
 
 ## Running atom-hydra
 1. restart atom

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "atom-hydra",
-      "version": "0.3.6",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "atom-message-panel": "^1.3.0",
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/atom-message-panel": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.0.tgz",
-      "integrity": "sha1-BOICKVQHZrzTVlVdq/qY1b7dMTw=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.1.tgz",
+      "integrity": "sha512-nLi19faNBl/kabrf6itBkHcLrnpUeiGbpda+dHufAODKH+I+odoPRCxx7EZ+mCHEsBMhHNXxLWOLA+Mm9pumbA==",
       "dependencies": {
         "atom-space-pen-views": "^2.2.0"
       }
@@ -32,7 +32,7 @@
     "node_modules/atom-space-pen-views": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/atom-space-pen-views/-/atom-space-pen-views-2.2.0.tgz",
-      "integrity": "sha1-plsskg7QL3JAFPp9Plw9ePv1mZc=",
+      "integrity": "sha512-PxwV0txlLlYLMdWKv4m4ZH3fdUguWxx+Pwr+abgFAmcqaiyAoAV66Be7W+dVymdY7y0qSHLc4KcsFkj9j3A9+A==",
       "dependencies": {
         "fuzzaldrin": "^2.1.0",
         "space-pen": "^5.1.2"
@@ -290,7 +290,7 @@
     "node_modules/jquery": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
-      "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
+      "integrity": "sha512-wWR+eCq/T/Qt0NcFyM+QVho0ZVzWxFYANijmSMImXiM5mjr1aOaf4SF0eOEPc92bbK2L2vDpxw3lIszus7eO8Q=="
     },
     "node_modules/meyda": {
       "version": "4.1.3",
@@ -419,7 +419,7 @@
     "node_modules/space-pen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz",
-      "integrity": "sha1-Ivu+EOCwROe3pHsCPamdlLWE748=",
+      "integrity": "sha512-+AunZHZblS3AjlZh13JCooLo+kQbkWBnC6TP1J4ZLEACx4F5rNhKXTV3v1bu2XVzuzNe+CxE2Eo5o2zEmplWhA==",
       "dependencies": {
         "grim": "^1.0.0",
         "jquery": "2.1.4",
@@ -452,16 +452,16 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/underscore-plus": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
-      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
       "dependencies": {
-        "underscore": "~1.6.0"
+        "underscore": "^1.9.1"
       }
     },
     "node_modules/util-deprecate": {
@@ -518,9 +518,9 @@
   },
   "dependencies": {
     "atom-message-panel": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.0.tgz",
-      "integrity": "sha1-BOICKVQHZrzTVlVdq/qY1b7dMTw=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.1.tgz",
+      "integrity": "sha512-nLi19faNBl/kabrf6itBkHcLrnpUeiGbpda+dHufAODKH+I+odoPRCxx7EZ+mCHEsBMhHNXxLWOLA+Mm9pumbA==",
       "requires": {
         "atom-space-pen-views": "^2.2.0"
       }
@@ -528,7 +528,7 @@
     "atom-space-pen-views": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/atom-space-pen-views/-/atom-space-pen-views-2.2.0.tgz",
-      "integrity": "sha1-plsskg7QL3JAFPp9Plw9ePv1mZc=",
+      "integrity": "sha512-PxwV0txlLlYLMdWKv4m4ZH3fdUguWxx+Pwr+abgFAmcqaiyAoAV66Be7W+dVymdY7y0qSHLc4KcsFkj9j3A9+A==",
       "requires": {
         "fuzzaldrin": "^2.1.0",
         "space-pen": "^5.1.2"
@@ -765,7 +765,7 @@
     "jquery": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
-      "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
+      "integrity": "sha512-wWR+eCq/T/Qt0NcFyM+QVho0ZVzWxFYANijmSMImXiM5mjr1aOaf4SF0eOEPc92bbK2L2vDpxw3lIszus7eO8Q=="
     },
     "meyda": {
       "version": "4.1.3",
@@ -882,7 +882,7 @@
     "space-pen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz",
-      "integrity": "sha1-Ivu+EOCwROe3pHsCPamdlLWE748=",
+      "integrity": "sha512-+AunZHZblS3AjlZh13JCooLo+kQbkWBnC6TP1J4ZLEACx4F5rNhKXTV3v1bu2XVzuzNe+CxE2Eo5o2zEmplWhA==",
       "requires": {
         "grim": "^1.0.0",
         "jquery": "2.1.4",
@@ -915,16 +915,16 @@
       }
     },
     "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "underscore-plus": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
-      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
       "requires": {
-        "underscore": "~1.6.0"
+        "underscore": "^1.9.1"
       }
     },
     "util-deprecate": {


### PR DESCRIPTION
## Summary
User's who set up atom-hydra via `npm link` need to manually install `package.json` dependencies since they are no longer handled by the Atom IDE. This PR adds the `npm install` step to the root-level README file to improve accessibility.

Resolves: #51, #50 

Also, I ran `npm audit fix` to remove 2 critical vulnerabilities. Here are the results.
**Before audit:**
```
❯ npm install
npm WARN deprecated dgram@1.0.1: npm is holding this package for security reasons. As it's a core Node module, we will not transfer it over to other users. You may safely remove the package from your dependencies.

added 63 packages, and audited 64 packages in 3s

6 vulnerabilities (4 moderate, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```
**Auditing:**
```
❯ npm audit fix

changed 6 packages, and audited 64 packages in 5s

# npm audit report

jquery  <=3.4.1
Severity: moderate
Cross-Site Scripting (XSS) in jquery - https://github.com/advisories/GHSA-rmxg-73gg-4p98
XSS in jQuery as used in Drupal, Backdrop CMS, and other products - https://github.com/advisories/GHSA-6c3j-c64m-qhgq
Potential XSS vulnerability in jQuery - https://github.com/advisories/GHSA-gxr4-xjj5-5px2
Potential XSS vulnerability in jQuery - https://github.com/advisories/GHSA-jpcq-cgw6-v4j6
fix available via `npm audit fix --force`
Will install atom-message-panel@1.2.4, which is a breaking change
node_modules/jquery
  space-pen  >=5.1.0
  Depends on vulnerable versions of jquery
  node_modules/space-pen
    atom-space-pen-views  >=2.1.1
    Depends on vulnerable versions of space-pen
    node_modules/atom-space-pen-views
      atom-message-panel  >=1.2.5
      Depends on vulnerable versions of atom-space-pen-views
      node_modules/atom-message-panel

4 moderate severity vulnerabilities
```
**Installing after:**
```
❯ npm install
npm WARN deprecated dgram@1.0.1: npm is holding this package for security reasons. As it's a core Node module, we will not transfer it over to other users. You may safely remove the package from your dependencies.

added 63 packages, and audited 64 packages in 2s

4 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```

P.S. lmk if you'd like to rebuild this plugin for VSCode or WebStorm. I'd be happy to lend a hand :) 