### PR TITLE
Add settings to choose audio input device

### DIFF
--- a/lib/atom-hydra.js
+++ b/lib/atom-hydra.js
@@ -3,10 +3,33 @@
 import Main from './main.js'
 import { CompositeDisposable } from 'atom'
 
-export default {
+let packageDefinition = {
   isActive: false,
   subscriptions: null,
   main: null,
+
+  config: {
+    audioInputDevice: {
+      type: 'string',
+      values: [{ value: "default", description: 'Default' }],
+      default: "default",
+      enumerateDevices: async function() {
+        let devices = await navigator.mediaDevices.enumerateDevices()
+        let inputDevices = []
+        for (const device of devices) {
+          if (device.kind == "audioinput") {
+            inputDevices.push({value: device.deviceId, description: device.label});
+          }
+        }
+        this.values = inputDevices
+        this.enumerateDevices = function() { return this.values }
+        return this.values;
+      },
+      get enum() {
+        return this.enumerateDevices()
+      }
+    }
+  },
 
   activate(state) {
     this.main = new Main()
@@ -47,3 +70,5 @@ export default {
   }
 
 };
+
+export default packageDefinition;

--- a/lib/main.js
+++ b/lib/main.js
@@ -186,7 +186,8 @@ export default class Main {
 
     this.hydra = new Hydra ({
       canvas: this.canvas,
-      autoLoop: false
+      autoLoop: false,
+      audioDeviceId: atom.config.get('atom-hydra.audioInputDevice')
     })
 
     // hijack source init screen event because doesn't work in Electron

--- a/menus/atom-hydra.json
+++ b/menus/atom-hydra.json
@@ -12,7 +12,7 @@
       "label": "Packages",
       "submenu": [
         {
-          "label": "atom-hydra",
+          "label": "Hydra",
           "submenu": [
             {
               "label": "Toggle",


### PR DESCRIPTION
In order for this PR to be ready to merge, a new version of hydra-synth containing the following PRs would need to be merged:
In order to make the audio input configurable from the outside:
https://github.com/hydra-synth/hydra-synth/pull/155
In order to make the new hydra-synth versions compatible with atom-hydra:
https://github.com/hydra-synth/hydra-synth/pull/156
