### PR TITLE
add missing 'var'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -77,7 +77,7 @@ export default class Main {
   evalCode() {
     let editor
     if (editor = atom.workspace.getActiveTextEditor()) {
-      range = {
+        var range = {
         start: { row: 0, column: 0 },
         end: { row: editor.getLastScreenRow() + 1, column: 0 }
       }


### PR DESCRIPTION
Fixes #66

'range' variable was not defined in this context. Contrast with `evalBlock()`